### PR TITLE
[BUG] Corrige les redirections côté client vers Pix Site (PS-20).

### DIFF
--- a/middleware/current-page-path.js
+++ b/middleware/current-page-path.js
@@ -1,5 +1,11 @@
 export default function(context) {
-  const { req, route } = context
+  const { req, route, redirect } = context
+  const shouldRedirect = !['/mediation-numerique', '/employeurs'].includes(
+    route.path
+  )
+  if (shouldRedirect) {
+    redirect(`https://pix.fr/${route.path}`)
+  }
   const host = req ? req.headers.host : window.location.host
   context.currentPagePath = `${host}${route.path}`
 }


### PR DESCRIPTION
## :unicorn: Problème
En chargeant directement l'url https://pro.pix.fr/qui-sommes-nous nous arrivons bien sur https://pix.fr/qui-sommes-nous. Cependant si on charge https://pro.pix.fr/ et qu'on clique sur l'entrée de menu `Qui sommes nous` on arrive sur https://pro.pix.fr/qui-sommes-nous au lieu de https://pix.fr/qui-sommes-nous. Cela est dû au fait que le `serverMiddleware` n'est appelé qu'au premier rendu.

## :robot: Solution
J'ai ajouté les redirections dans le middleware utilisé par le routeur pour qu'elles soient aussi appliquées au changement de page.

