### PR TITLE
[FEATURE] Ajout de la séparation de Pix Pro du reste de la navigation (PS-22).

### DIFF
--- a/assets/scss/components/_app-navbar.scss
+++ b/assets/scss/components/_app-navbar.scss
@@ -90,7 +90,7 @@
     }
 
     > .container {
-      height: 90px;
+      height: 52px;
     }
 
     .container {
@@ -99,8 +99,7 @@
     }
 
     .logo {
-      width: 82px;
-      height: 62px;
+      height: 43px;
       margin-right: 18px;
 
       @include device-is('tablet') {
@@ -113,10 +112,14 @@
       flex-flow: row;
       justify-content: flex-end;
       width: 100%;
-      align-items: center;
+      height: 100%;
 
       .text-black {
+        display: flex;
+        align-items: center;
+        height: 100%;
         margin-right: 24px;
+        font-family: $roboto;
 
         &:last-child {
           margin-right: 0;
@@ -126,6 +129,14 @@
 
     .desktop {
       width: 100%;
+      height: 100%;
     }
+
+    &.mobile {
+      > .container {
+        height: 87px;
+      }
+    }
+
   }
 }

--- a/assets/scss/components/_main-nav.scss
+++ b/assets/scss/components/_main-nav.scss
@@ -1,3 +1,24 @@
 .btn-nav {
+  align-self: center;
   transition: all ease-in .2s;
+}
+
+.link-separator-left {
+  position: relative;
+  margin-left: 24px;
+  padding: 0 12px;
+}
+
+.link-separator-left::before {
+  position: absolute;
+  left: -24px;
+  content: ' ';
+  height: 30px;
+  border-left: 1px solid $grey-9;
+}
+
+.link-separator-left.link-active {
+  color: $blue-6;
+  font-weight: 700;
+  border-bottom: 3px solid $blue-6;
 }

--- a/assets/scss/globals/_colors.scss
+++ b/assets/scss/globals/_colors.scss
@@ -6,6 +6,7 @@ $grey-5: #666666;
 $grey-6: #444444;
 $grey-7: #DDDDDD;
 $grey-8: #FAFBFC;
+$grey-9: #96a0af;
 
 $blue-1: #3D68FF;
 $blue-2: #12A3FF;

--- a/components/main-nav.vue
+++ b/components/main-nav.vue
@@ -1,17 +1,21 @@
 <template>
   <div class="navigation">
-    <a href="https://pix.fr" class="text text-xs text-left regular text-black">
-      <p>
-        Accueil
-      </p>
-    </a>
     <pix-link
-      v-for="item in navItems"
+      v-for="(item, index) in mainNavItems"
       :key="item.id"
       :field="item.primary.link"
-      class="text text-xs text-left regular text-black"
+      :class="[
+        'text',
+        'text-xs',
+        'text-left',
+        'regular',
+        { 'text-black': index < mainNavItems.length - 1 },
+        { 'link-separator-left': index === mainNavItems.length - 3 },
+        { 'link-active': isPixProActive(index) },
+        { 'btn-nav': index === mainNavItems.length - 1 }
+      ]"
     >
-      <prismic-rich-text :field="item.primary.title" />
+      {{ $prismic.richTextAsPlain(item.primary.title) }}
     </pix-link>
   </div>
 </template>
@@ -25,12 +29,11 @@ export default {
       default: null
     }
   },
-  computed: {
-    navItems() {
-      return this.mainNavItems.filter((navItem) => {
-        const [{ text }] = navItem.primary.title
-        return text !== 'Accueil'
-      })
+  methods: {
+    isPixProActive(index) {
+      return ['/employeurs', '/mediation-numerique'].includes(
+        this.$nuxt.$route.path
+      )
     }
   }
 }


### PR DESCRIPTION
## :unicorn: Problème
Il manque le séparateur à gauche du lien Pix Pro dans la navigation.

## :robot: Solution
Ajout du séparateur et du style du lien de navigation Pix Pro.

## :rainbow: Remarques
J'en ai profité pour rapprocher le style du bandeau de la cible v2.
