### PR TITLE
[BUG] Corrige la page oups au clic sur le logo Pix sur mobile (PS-24).

### DIFF
--- a/components/header-nav.vue
+++ b/components/header-nav.vue
@@ -13,7 +13,7 @@
       <div class="nav-principal mobile">
         <div class="container padding-container">
           <div class="switch">
-            <nuxt-link to="https://pix.fr">
+            <nuxt-link to="/">
               <img
                 alt="Accueil du site pix.fr"
                 class="logo"


### PR DESCRIPTION
## :unicorn: Problème
Quand on clic sur le logo Pix sur mobile on arrive sur une page oups.

## :robot: Solution
Corrige le lien présent sur le logo Pix en mode mobile.
