### PR TITLE
[FEATURE] Changer breakpoint pour l’affichage du menu burger de Pix Pro (PS-27).

### DIFF
--- a/assets/scss/components/_app-navbar.scss
+++ b/assets/scss/components/_app-navbar.scss
@@ -4,7 +4,7 @@
     height: 68px;
     background-color: $grey-8;
 
-    @include device-is('tablet') {
+    @include device-is('desktop') {
       display: flex;
     }
 

--- a/assets/scss/globals/_breakpoints.scss
+++ b/assets/scss/globals/_breakpoints.scss
@@ -1,6 +1,7 @@
 $breakpoints: (
   'large-mobile': (min-width: 600px),
-  'tablet': (min-width: 768px)
+  'tablet': (min-width: 768px),
+  'desktop': (min-width: 960px)
 ) !default;
 
 /*

--- a/assets/scss/globals/_globals.scss
+++ b/assets/scss/globals/_globals.scss
@@ -105,7 +105,7 @@ ol {
 .desktop {
   display: none !important;
 
-  @include device-is('tablet') {
+  @include device-is('desktop') {
     display: block !important;
   }
 }
@@ -113,8 +113,16 @@ ol {
 .desktop-inline {
   display: none;
 
-  @include device-is('tablet') {
+  @include device-is('desktop') {
     display: inline;
+  }
+}
+
+.tablet {
+  display: block;
+
+  @include device-is('desktop') {
+    display: none;
   }
 }
 

--- a/components/burger-menu-nav.vue
+++ b/components/burger-menu-nav.vue
@@ -63,7 +63,7 @@ export default {
   background: linear-gradient(134.72deg, $blue-2 0%, $blue-1 100%);
   padding-top: 0;
 
-  @include device-is('tablet') {
+  @include device-is('desktop') {
     display: none;
   }
 
@@ -209,7 +209,7 @@ export default {
 
 .bm-burger-button {
   z-index: 1;
-  @include device-is('tablet') {
+  @include device-is('desktop') {
     display: none;
   }
 }

--- a/components/header-nav.vue
+++ b/components/header-nav.vue
@@ -10,7 +10,7 @@
           />
         </push-menu>
       </client-only>
-      <div class="nav-principal mobile">
+      <div class="nav-principal tablet">
         <div class="container padding-container">
           <div class="switch">
             <nuxt-link to="/">


### PR DESCRIPTION
## :unicorn: Problème
Le menu s'affiche difficilement sur les petites resolutions.

## :robot: Solution
Change le breakpoint d'affichage de menu mobile pour qu'il soit visible jusqu'à 960px.