### PR TITLE
[BUG] Corrige la taille de l'entête sur mobile et tablette

### DIFF
--- a/assets/scss/components/_app-navbar.scss
+++ b/assets/scss/components/_app-navbar.scss
@@ -132,7 +132,7 @@
       height: 100%;
     }
 
-    &.mobile {
+    &.tablet {
       > .container {
         height: 87px;
       }


### PR DESCRIPTION
## :unicorn: Problème
La taille de l'entête est trop petite sur mobile et tablette. Par conséquent le bouton du menu dépasse.

## :robot: Solution
Augmentation de la taille de l'entête sur mobile et tablette
