### PR TITLE
[BUGFIX] Le bouton du burger-menu s'affichait sur les hot news (PS-36).

### DIFF
--- a/components/burger-menu-nav.vue
+++ b/components/burger-menu-nav.vue
@@ -214,6 +214,12 @@ export default {
   }
 }
 
+.nav .bm-burger-button {
+  top: 23px;
+  position: relative;
+  margin-bottom: -36px;
+}
+
 .bm-cross {
   background: $grey-1;
   height: 24px !important;


### PR DESCRIPTION
## :unicorn: Problème
- Quand il y a des Hot News, le bouton du burger menu s'affichait par dessus et n'était pas visible.
- La position du bouton est dans le code du plugin du burger-menu

## :robot: Solution
- Le code du bouton indiquant une `position: absolute` avec un `top`fixe, j'ai dû passer au dessus en précisant la classe `.nav .bm-burger-button`(qui a plus de poids que juste `.bm-burger-button` pour le rendre en position relative, avec un top différent (lié au contexte) et un `margin-bottom` negatif  pour que la hauteur du bouton n'empiète pas sur le reste de la navigation

## :rainbow: Remarques
- Il faudrait revoir tout le squelette de la navigation pour que le bouton soit bien aligné dans la navigation
- Ces modifications sont aussi à faire dans pix-site : https://github.com/1024pix/pix-site/pull/112

## :sparkles: Review App
https://pix-pro-review-pr9.osc-fr1.scalingo.io