### PR TITLE
[BUGFIX] Pouvoir fermer le bandeau des hot news (PS-37).

### DIFF
--- a/components/hot-news-banner.vue
+++ b/components/hot-news-banner.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="isOpen" class="hot-news">
+  <div v-if="isOpen && hotNews" class="hot-news">
     <prismic-rich-text :field="hotNews" />
     <img class="close" src="/images/close-icon.svg" @click.stop="closeBanner" />
   </div>
@@ -12,7 +12,7 @@ export default {
   name: 'HotNewsBanner',
   data() {
     return {
-      isOpen: this.hotNews
+      isOpen: true
     }
   },
   computed: mapState(['hotNews']),

--- a/components/hot-news-banner.vue
+++ b/components/hot-news-banner.vue
@@ -66,6 +66,7 @@ export default {
   opacity: 0.5;
   transition: 0.5s;
   cursor: pointer;
+  height: 20px;
 
   @media (min-width: 769px) {
     margin-right: 32px;


### PR DESCRIPTION
## :unicorn: Problème
- La croix pour fermer le bandeau des nouvelles ne fonctionnait pas

## :robot: Solution
- Pour savoir si on l'affichait, on se basait sur la présence d'une `hotnews` et on mettait la variable 
 `isOpen` a false une fois fermée.
- Séparation de la div permettant de savoir s'il y a une news et de celle pour savoir si l'utilisateur a fermé ou non.

## :rainbow: Remarques
- Faire la même chose sur pix-site : https://github.com/1024pix/pix-site/pull/113

## :sparkles: Review App
https://pix-pro-review-pr10.osc-fr1.scalingo.io