### PR TITLE
[BUGFIX] Le texte Pix Pro a un titre alors que ce n'en ait pas un (PIX-873).

### DIFF
--- a/components/burger-menu-nav.vue
+++ b/components/burger-menu-nav.vue
@@ -10,7 +10,7 @@
       </ul>
       <div class="nav-middle">
         <hr class="nav-middle__bar" />
-        <h3>Pix Pro</h3>
+        <p>Pix Pro</p>
         <ul>
           <li
             v-for="item in middleItems"


### PR DESCRIPTION
## :unicorn: Problème
Contexte Sur les sites vitrine, lorsqu'on regarde les headers, le premier que l'on a est un H3 pour le lien vers Pix-pro.

## :robot: Solution
Remplacer le H3 par un P